### PR TITLE
commandChanVim.py: fix hjkl keybinds

### DIFF
--- a/commandChanVim.py
+++ b/commandChanVim.py
@@ -164,15 +164,16 @@ class urwidView():
             self.displayFrame()
 
         if self.mode is MODE.NORMAL:
+            rows, cols = urwid.raw_display.Screen().get_cols_rows()
             DEBUG(key)
             if key == 'h':
-                self.frame.keypress((95,60), 'left')
+                self.frame.keypress((rows,cols), 'left')
             if key == 'j':
-                self.frame.keypress((95,60), 'down')
+                self.frame.keypress((rows,cols), 'down')
             if key == 'k':
-                self.frame.keypress((95,60), 'up')
+                self.frame.keypress((rows,cols), 'up')
             if key == 'l':
-                self.frame.keypress((95,60), 'right')
+                self.frame.keypress((rows,cols), 'right')
             if key == 'r':
                 if self.level is LEVEL.BOARD:
                     DEBUG('refreshing')

--- a/commandChanVim.py
+++ b/commandChanVim.py
@@ -166,13 +166,13 @@ class urwidView():
         if self.mode is MODE.NORMAL:
             DEBUG(key)
             if key == 'h':
-                self.frame.keypress((100,100), 'left')
+                self.frame.keypress((95,60), 'left')
             if key == 'j':
-                self.frame.keypress((150,100), 'down')
+                self.frame.keypress((95,60), 'down')
             if key == 'k':
-                self.frame.keypress((150,100), 'up')
+                self.frame.keypress((95,60), 'up')
             if key == 'l':
-                self.frame.keypress((100,100), 'right')
+                self.frame.keypress((95,60), 'right')
             if key == 'r':
                 if self.level is LEVEL.BOARD:
                     DEBUG('refreshing')


### PR DESCRIPTION
**HJKL Movement Fix**

The issue here was that the size specified to the keypress argument was not the actual size of the thread box widgets specified in [threadViewClasses.py](https://github.com/wtheisen/commandChan/blob/master/threadViewClasses.py) line 75, which is (95, 60). Might be a good idea to go ahead and make these sizes members of the urwidView class so as not to be hardcoded. yeet