### PR TITLE
feat/reddit: toggle stickied status

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ To run `python3 commandChanVim.py`
 - (s)earch [PATTERN] - filters the current view to only items containing [PATTERN], if [PATTERN] is empty it will reset the search and refresh the current view
 - (t)hread [THREAD NUMBER] - open the thread on the current board with the specified number
 - (h)istory [INDEX] - open the thread located in [INDEX] in the history queue, if [INDEX] is not specified then it opens the previously viewed thread
+- stickies - toggle between showing and hiding stickies
 - reddit - switch client to reddit mode
 - 4chan - switch client to 4chan mode
 
@@ -47,10 +48,11 @@ To run `python3 commandChanVim.py`
 - [X] Display images links on posts
 - [X] Board and Thread fetch information in the footer
 - [X] Filtering options on all pages with information in the footer
-- [ ] HJKL movement (HL work right now, JK don't for some reason)
+- [X] HJKL movement
 - [ ] Full suite of commands
     - [X] Search command for current view
     - [X] Thread command to view thread by number
+    - [X] Toggle to show or hide stickied reddit posts
 - [ ] Toggleable display modes(boxes, tree, cascade)
 - [ ] Display comment replies in the info bar at the top of the comment
 - [ ] Save threads to a custom hotkey menu

--- a/autocomplete.py
+++ b/autocomplete.py
@@ -1,6 +1,7 @@
 commandList = [
                 'search',
                 'thread',
+                'stickies',
                 'board',
                 'post',
                 'reply',

--- a/boardClass.py
+++ b/boardClass.py
@@ -1,7 +1,7 @@
 #Board Meta-class
 import requests, collections, json, time
 
-from customeTypes import VIEWSTYLES, SITE
+from customeTypes import VIEWSTYLES, SITE, STICKIES
 from boardViewClasses import buildView
 from debug import DEBUG
 
@@ -56,6 +56,9 @@ class Board:
         posts = data['data']['children']
 
         for post in posts:
+            if self.uvm.stickies == STICKIES.HIDE and post['data']['stickied']:
+                continue
+
             titles[post['data']['title']] = (post['data']['permalink'],
                                              post['data']['score'],
                                              post['data']['subreddit'])

--- a/commandChanVim.py
+++ b/commandChanVim.py
@@ -13,7 +13,7 @@ from debug import INITDEBUG, DEBUG
 
 from customUrwidClasses import CommandBar, HistoryButton
 from commandHandlerClass import CommandHandler
-from customeTypes import LEVEL, MODE, SITE
+from customeTypes import LEVEL, MODE, SITE, STICKIES
 
 ################################################################################
 
@@ -21,6 +21,7 @@ class urwidView():
     def __init__(self):
         self.level  = LEVEL.INDEX
         self.mode   = MODE.NORMAL
+        self.stickies = STICKIES.SHOW
         self.cfg    = Config()
         self.site   = SITE[self.cfg.get('SITE')]
         self.boards = self.cfg.get(self.site.name)['boards']

--- a/commandChanVim.py
+++ b/commandChanVim.py
@@ -21,7 +21,7 @@ class urwidView():
     def __init__(self):
         self.level  = LEVEL.INDEX
         self.mode   = MODE.NORMAL
-        self.stickies = STICKIES.SHOW
+        self.stickies = STICKIES.HIDE
         self.cfg    = Config()
         self.site   = SITE[self.cfg.get('SITE')]
         self.boards = self.cfg.get(self.site.name)['boards']

--- a/commandHandlerClass.py
+++ b/commandHandlerClass.py
@@ -3,7 +3,7 @@ import urwid
 import commands
 
 from debug import DEBUG
-from customeTypes import SITE
+from customeTypes import SITE, STICKIES
 
 class CommandHandler:
     def __init__(self, urwidViewManager):
@@ -36,3 +36,6 @@ class CommandHandler:
             DEBUG('executing site command')
             self.uvm.site = SITE.REDDIT if cmd[0] == 'reddit' else SITE.FCHAN
             commands.site(self.uvm)
+        if cmd[0] == 'stickies':
+           self.uvm.stickies = STICKIES.HIDE if self.uvm.stickies == STICKIES.SHOW else STICKIES.SHOW
+           commands.refresh(self.uvm)

--- a/commands.py
+++ b/commands.py
@@ -46,5 +46,16 @@ def history(uvm):
     preCommand(uvm)
     uvm.thread = Thread(uvm)
     uvm.buildAddHeaderView()
-    uvm.buildAddFooterView
+    uvm.buildAddFooterView()
+    uvm.displayFrame()
+
+# For toggling stickies, auto refresh. Could use this func in other places if wish to rebase a lil
+def refresh(uvm):
+    uvm.mode = MODE.NORMAL
+    if uvm.level is LEVEL.BOARD:
+        uvm.displayBoard(uvm, uvm.boardString)
+    elif uvm.level is LEVEL.THREAD:
+        uvm.displayThread(uvm, uvm.threadID)
+    uvm.buildAddHeaderView()
+    uvm.buildAddFooterView()
     uvm.displayFrame()

--- a/customeTypes.py
+++ b/customeTypes.py
@@ -18,3 +18,7 @@ class MODE(Enum):
 class SITE(Enum):
     FCHAN  = 0
     REDDIT = 1
+
+class STICKIES(Enum):
+    SHOW = 0
+    HIDE = 1


### PR DESCRIPTION
As discussed in issue #3 , added feat for toggling between sticky status for reddit posts. The command is `stickies`. Works well, auto refreshes board after toggle. I made a command `refresh` that is called when this command is invoked, which does the exact same thing that the `r` key does. This might not be important but it might make sense to have an outright refresh func used for both cases, and there may be more cases for refreshing down the road.

Next steps: add default sticky status to reddit config