### PR TITLE
autocomplete.py: allow toggling of matches

### DIFF
--- a/autocomplete.py
+++ b/autocomplete.py
@@ -23,14 +23,15 @@ def autoComplete(editBox):
     if len(inputList) == 1: #completing first bit
         currCommand = currText.split()[0]
         matches = [x for x in commandList if x.startswith(currCommand)]
-        try:
-            match = min(matches, key=len)
-            if currCommand in commandList:
-                try:
-                    match = matches[1]
-                except IndexError:
-                    pass
-            editBox.set_edit_text(match)
-            editBox.set_edit_pos(len(match))
-        except ValueError:
-            pass
+        # Check to toggle for previous match
+        if len(matches) == 1:
+            currCommand = currCommand[:3]
+            matches = [x for x in commandList if x.startswith(currCommand)]
+        match = min(matches, key=len)
+        if currCommand in commandList:
+            try:
+                match = matches[1]
+            except IndexError:
+                pass
+        editBox.set_edit_text(match)
+        editBox.set_edit_pos(len(match))

--- a/autocomplete.py
+++ b/autocomplete.py
@@ -35,3 +35,5 @@ def autoComplete(editBox):
                 pass
         editBox.set_edit_text(match)
         editBox.set_edit_pos(len(match))
+    elif len(inputList) == 2:
+        pass

--- a/autocomplete.py
+++ b/autocomplete.py
@@ -1,6 +1,9 @@
+from debug import DEBUG
 commandList = [
                 'search',
                 'thread',
+                'stickies',
+                'history',
                 'board',
                 'post',
                 'reply',
@@ -13,15 +16,21 @@ commandList = [
 def autoComplete(editBox):
     currText = editBox.get_edit_text()
     try:
-        inputList = currText.split()[0]
+        inputList = currText.split()
     except IndexError:
         return
 
     if len(inputList) == 1: #completing first bit
         currCommand = currText.split()[0]
         matches = [x for x in commandList if x.startswith(currCommand)]
-        shortestMatch = min(matches, key=len)
-        editBox.set_edit_text(shortestMatch)
-        editBox.set_edit_pos(len(shortestMatch))
-    elif len(inputList) == 2: #completing argument
-        pass
+        try:
+            match = min(matches, key=len)
+            if currCommand in commandList:
+                try:
+                    match = matches[1]
+                except IndexError:
+                    pass
+            editBox.set_edit_text(match)
+            editBox.set_edit_pos(len(match))
+        except ValueError:
+            pass


### PR DESCRIPTION
Not sure if this was an issue for anyone else, but autocomplete for commands was not working for me. It was using a variable, `inputList`, that wasn't a list. The variable was the first item in the list returned from `.split()`. So I:

1. Made inputList a list, so it works with the already in place code that checks its length
2. currCommand indexes the list to get the first item
3. Add tab completion for next match, i.e. if the input command is `thread` and you press tab, it autocompletes to `threadView`. Previously it would just stay as `thread`
4. Toggle between autocompletion, i.e. if I tab complete to `thread`, then `threadView`, I can press tab once more to go back to `thread`, and so on.

The logic for the toggling auto completion is a little jank so just lmk if you want it reworked.