### PR TITLE
fix fatal error if no matches found

### DIFF
--- a/autocomplete.py
+++ b/autocomplete.py
@@ -24,7 +24,9 @@ def autoComplete(editBox):
         currCommand = currText.split()[0]
         matches = [x for x in commandList if x.startswith(currCommand)]
         # Check to toggle for previous match
-        if len(matches) == 1:
+        if not len(matches):
+            return
+        elif len(matches) == 1:
             currCommand = currCommand[:3]
             matches = [x for x in commandList if x.startswith(currCommand)]
         match = min(matches, key=len)


### PR DESCRIPTION
wasn't checking if matches weren't found - now does. program would crash if the length was 0, now it just returns to ignore that jawn. my b for not checking that in the OG commit/PR