### PR TITLE
ignoring .env for vscode stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .vscode/
 __pycache__/
 venv/
+.env


### PR DESCRIPTION
Fixed the pythonpath issue for my vscode, but I dont think the .env file should be in the repo, so added it to the gitignore