### PR TITLE
Update some command logic

### DIFF
--- a/src/Commands/ChanCommands.py
+++ b/src/Commands/ChanCommands.py
@@ -5,6 +5,11 @@ from Frames.defaultFrame import FrameFactory
 from Frames.fchan.boardFrame import BoardFrame
 from Frames.fchan.threadFrame import ThreadFrame
 
+ChanCommandList = [
+    'b', 'board',
+    't', 'thread'
+]
+
 def chanCommands(cmd, uvm):
     cmd = cmd.split()
 

--- a/src/Commands/RedditCommands.py
+++ b/src/Commands/RedditCommands.py
@@ -5,6 +5,11 @@ from Frames.defaultFrame import FrameFactory
 from Frames.reddit.subredditFrame import SubredditFrame
 from Frames.reddit.threadFrame import RedditThreadFrame
 
+RedditCommandList = [
+    'sub', 'subreddit',
+    'p', 'post'
+]
+
 def redditCommands(cmd, uvm):
     cmd = cmd.split()
 

--- a/src/Commands/SystemCommands.py
+++ b/src/Commands/SystemCommands.py
@@ -95,7 +95,7 @@ def systemCommands(cmd, uvm):
                 # setattr(uvm.currFocusView, 'boardList', uvm.boardList)
                 uvm.currFocusView.updateHistory(FrameFactory([uvm], IndexFrame))
                 setattr(uvm.currFocusView, 'frame', IndexFrame(uvm))
-            elif cmd[1] == ['reddit', 'Reddit']:
+            elif cmd[1] in ['reddit', 'Reddit']:
                 setattr(uvm.currFocusView, 'site', SITE.REDDIT)
                 # setattr(uvm.currFocusView, 'boardList', uvm.subredditList)
                 uvm.currFocusView.updateHistory(FrameFactory([uvm], RedditIndexFrame))

--- a/src/Commands/SystemCommands.py
+++ b/src/Commands/SystemCommands.py
@@ -122,7 +122,3 @@ def systemCommands(cmd, uvm):
         if len(uvm.splitTuple.widgets) > 1:
             uvm.splitTuple.widgets.pop() # doesn't work for mix of split and vsplit
 
-    else:
-        return False
-
-    return True

--- a/src/Commands/SystemCommands.py
+++ b/src/Commands/SystemCommands.py
@@ -35,7 +35,7 @@ def systemCommands(cmd, uvm):
         DEBUG('Executing quit command')
         sys.exit()
 
-    elif cmd[0] in ('add'):
+    elif cmd[0] == ('add'):
         if len(cmd) >= 3:
             DEBUG(f'Executing add command with args: {cmd[1:]}')
             if cmd[1] == '4chan':
@@ -45,10 +45,10 @@ def systemCommands(cmd, uvm):
                 for subreddit in cmd[2:]:
                     uvm.subredditList.append(subreddit)
 
-    elif cmd[0] in ('set'):
+    elif cmd[0] == ('set'):
         pass
 
-    elif cmd[0] in ('source'):
+    elif cmd[0] == ('source'):
         pass
         try:
             with open(cmd[1], 'r') as rcFile:
@@ -73,14 +73,13 @@ def systemCommands(cmd, uvm):
 
     elif cmd[0] in ('s', 'search'):
         h = uvm.history[0]
-        DEBUG(uvm.history)
         newArgs = h[2].copy()
         if len(cmd) is 2:
             newArgs.append(cmd[1])
 
         setattr(uvm.currFocusView, 'frame', h[1](newArgs))
 
-    elif cmd[0] in ('view'):
+    elif cmd[0] == ('view'):
         DEBUG('executing site command')
         DEBUG(cmd)
         if len(cmd) == 2:
@@ -101,7 +100,7 @@ def systemCommands(cmd, uvm):
                 uvm.currFocusView.updateHistory(FrameFactory([uvm], RedditIndexFrame))
                 setattr(uvm.currFocusView, 'frame', RedditIndexFrame(uvm))
 
-    elif cmd[0] in ('split'):
+    elif cmd[0] == ('split'):
         if type(uvm.splitTuple) is Row:
             uvm.splitTuple.widgets.append(View(uvm))
         else:
@@ -110,7 +109,7 @@ def systemCommands(cmd, uvm):
             uvm.splitTuple.widgets.append(t)
             uvm.splitTuple.widgets.append(View(uvm))
 
-    elif cmd[0] in ('vsplit'):
+    elif cmd[0] == ('vsplit'):
         if type(uvm.splitTuple) is Column:
             uvm.splitTuple.widgets.append(View(uvm))
         t = uvm.splitTuple
@@ -118,7 +117,7 @@ def systemCommands(cmd, uvm):
         uvm.splitTuple.widgets.append(t)
         uvm.splitTuple.widgets.append(View(uvm))
 
-    elif cmd[0] in ('unsplit'):
+    elif cmd[0] == ('unsplit'):
         if len(uvm.splitTuple.widgets) > 1:
             uvm.splitTuple.widgets.pop() # doesn't work for mix of split and vsplit
 

--- a/src/autocomplete.py
+++ b/src/autocomplete.py
@@ -1,16 +1,8 @@
 from Commands.SystemCommands import SystemCommandList
+from Commands.ChanCommands import ChanCommandList
+from Commands.RedditCommands import RedditCommandList
 from debug import DEBUG
-commandList = [
-                'thread',
-                'stickies',
-                'board',
-                'post',
-                'reply',
-                'threadStyle',
-                'boardStyle',
-                'reddit',
-                '4chan'
-            ]
+
 
 def autoComplete(editBox):
     currText = editBox.get_edit_text()
@@ -19,15 +11,17 @@ def autoComplete(editBox):
     except IndexError:
         return
 
+    commandList = (SystemCommandList + ChanCommandList + RedditCommandList)
+
     if len(inputList) == 1: #completing first bit
         currCommand = currText.split()[0]
-        matches = [x for x in (commandList + SystemCommandList) if x.startswith(currCommand)]
+        matches = [x for x in commandList if x.startswith(currCommand)]
         # Check to toggle for previous match
         if not len(matches):
             return
         elif len(matches) == 1:
-            currCommand = currCommand[:3]
-            matches = [x for x in (commandList + SystemCommandList) if x.startswith(currCommand)]
+            currCommand = currCommand[:2]
+            matches = [x for x in commandList if x.startswith(currCommand)]
         match = min(matches, key=len)
         if currCommand in commandList:
             try:

--- a/src/commandHandlerClass.py
+++ b/src/commandHandlerClass.py
@@ -1,8 +1,8 @@
 import urwid, sys
 
-from Commands.SystemCommands import SystemCommandList, systemCommands
-from Commands.ChanCommands import chanCommands
-from Commands.RedditCommands import redditCommands
+from Commands.SystemCommands import systemCommands, SystemCommandList
+from Commands.ChanCommands import chanCommands, ChanCommandList
+from Commands.RedditCommands import redditCommands, RedditCommandList
 
 from debug import DEBUG
 from customeTypes import SITE, MODE
@@ -26,16 +26,14 @@ class CommandHandler:
         self.preCommand()
 
         DEBUG(cmd)
-        if cmd.split()[0] in SystemCommandList:
-            # if matched return
-            if systemCommands(cmd, self.uvm):
-                self.postCommand()
-                return
 
-        # DEBUG(self.uvm.site)
-        if self.uvm.currFocusView.site is SITE.FCHAN:
+        if cmd.split()[0] not in (SystemCommandList + ChanCommandList + RedditCommandList):
+            return
+        elif cmd.split()[0] in SystemCommandList:
+            systemCommands(cmd, self.uvm)
+        elif self.uvm.currFocusView.site is SITE.FCHAN and cmd.split()[0] in ChanCommandList:
             chanCommands(cmd, self.uvm)
-        if self.uvm.currFocusView.site is SITE.REDDIT:
+        elif self.uvm.currFocusView.site is SITE.REDDIT and cmd.split()[0] in RedditCommandList:
             redditCommands(cmd, self.uvm)
 
         self.postCommand()

--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -10,10 +10,10 @@ import pytest
 
 test_list = [
     ('too long command', 'too long command'),
-    ('sti', 'stickies'), # input len 3
+    ('thr', 'thread'), # input len 3
     ('po', 'post'), # input len 2
-    ('re', 'reply'), # 2 cmds start with re
-    ('threadStyle', 'thread'), # toggle check
+    ('re', 'refresh'), # 2 cmds start with re
+    ('subreddit', 'sub'), # toggle check
     ('qsuaik', 'qsuaik') # gibberish
 ]
 


### PR DESCRIPTION
# Description

Began working on this branch to add new functionality to autocomplete but decided to work on some of the command routing logic instead. `autocomplete.py` now imports two new lists, `RedditCommandList` and `ChanCommandList`, to create an aggregate `commandList` to refer to for autocompletion. These lists also help with the logic for `routeCommand` in `commandHandlerClass`. Using these defined lists of commands allows to check just once to see if a command can be run or not - there is also now no need to return a bool from `systemCommands` as the only command that can be entered must be contained in `SystemCommandList`.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style of this project
- [X] I have performed a self-review of my own code
- [X] My code is self documenting
- [X] My changes generate no new major crashes/bugs