### PR TITLE
The WidgetWrap init gets called from the method in the abstract class…

### DIFF
--- a/src/Frames/abstractFrame.py
+++ b/src/Frames/abstractFrame.py
@@ -7,6 +7,7 @@ class AbstractFrame(urwid.WidgetWrap):
         self.uFilter = uFilter
         
         self.footerStringRight = None
+        self.contents = None
 
         # To measure how fast we load in the data
         self.startTime = None
@@ -22,3 +23,8 @@ class AbstractFrame(urwid.WidgetWrap):
         self.endTime = time.time()
         self.footerStringRight = f'Parsed {self.parsedItems} items in {(self.endTime - self.startTime):.4f}s'
 
+        # self.contents MUST BE SET in self.loader()
+        if self.contents == None:
+            raise ValueError(object)
+        
+        urwid.WidgetWrap.__init__(self, self.contents)

--- a/src/Frames/fchan/boardFrame.py
+++ b/src/Frames/fchan/boardFrame.py
@@ -13,13 +13,11 @@ class BoardFrame(AbstractFrame):
 
         self.load()
         self.headerString = f'commandChan: {self.boardString}'
-
-        self.contents = urwid.Pile(self.buildFrame(boardString))
-        urwid.WidgetWrap.__init__(self, self.contents)
     
     # Overrides super
     def loader(self):
         self.titles = self.getJSONCatalog(self.url)
+        self.contents = urwid.Pile(self.buildFrame(boardString))
 
     def buildFrame(self, board):
         '''returns the board widget'''

--- a/src/Frames/fchan/indexFrame.py
+++ b/src/Frames/fchan/indexFrame.py
@@ -14,8 +14,6 @@ class IndexFrame(AbstractFrame):
 
         DEBUG(self.uvm.history)
 
-        urwid.WidgetWrap.__init__(self, self.contents)
-
     # Overrides super
     def loader(self):
         self.contents = self.buildFrame()

--- a/src/Frames/fchan/threadFrame.py
+++ b/src/Frames/fchan/threadFrame.py
@@ -29,7 +29,6 @@ class ThreadFrame(AbstractFrame):
     def loader(self):
         self.comments = self.getJSONThread()
         self.contents = self.buildFrame()
-        urwid.WidgetWrap.__init__(self, self.contents)
 
     def getJSONThread(self):
         response = requests.get(self.url + '.json', headers=self.headers)

--- a/src/Frames/historyFrame.py
+++ b/src/Frames/historyFrame.py
@@ -3,30 +3,22 @@ import urwid, time, re
 from functools import partial
 
 from debug import DEBUG
+from abstractFrame import AbstractFrame
 
-class HistoryFrame(urwid.WidgetWrap):
-    HistoryFrameFactory = lambda x: HistoryFrame(*x)
-
+class HistoryFrame(AbstractFrame):
     def __init__(self, urwidViewManager, uFilter = None):
-        self.uvm = urwidViewManager
-        self.uFilter = uFilter
-
-
-        self.startTime = time.time()
-        self.contents = self.buildFrame()
-        urwid.WidgetWrap.__init__(self, self.contents)
-
-        self.endTime = time.time()
-
+        super().__init__(urwidViewManager, uFilter)
+        self.load()
         self.headerString = f'commandChan: History'
-        self.footerStringRight = f'Parsed {self.parsedItems} items in {(self.endTime - self.startTime):.4f}s'
 
+    def loader(self):
+        self.contents = self.buildFrame()
+        
     def buildFrame(self):
         listbox = self.buildThread()
         return urwid.Pile([listbox])
 
     def buildThread(self):
-
         historyWidgetList = []
         for h in self.uvm.history:
             frame = h[0]
@@ -42,9 +34,6 @@ class HistoryFrame(urwid.WidgetWrap):
                 hInfo = urwid.Text(f'Frame: {frame}, Info: {args}')
                 hButton = urwid.Button(f'{self.uvm.history.index(h)}: Restore', self.restore)
                 historyWidgetList.append(urwid.LineBox(urwid.Pile([hInfo, urwid.Divider('-'), hButton])))
-
-
-
 
         self.parsedItems = len(historyWidgetList)
 

--- a/src/Frames/reddit/indexFrame.py
+++ b/src/Frames/reddit/indexFrame.py
@@ -9,7 +9,6 @@ class RedditIndexFrame(AbstractFrame):
         self.headerString = 'commandChan'
 
         self.load()
-        urwid.WidgetWrap.__init__(self, self.contents)
     
     # Overrides super
     def loader(self):

--- a/src/Frames/reddit/subredditFrame.py
+++ b/src/Frames/reddit/subredditFrame.py
@@ -25,7 +25,6 @@ class SubredditFrame(AbstractFrame):
     def loader(self):
         self.titles = self.getJSONCatalog(self.url)
         self.contents = urwid.Pile(self.buildFrame(subreddit))
-        urwid.WidgetWrap.__init__(self, self.contents)
 
     def buildFrame(self, board):
         '''returns the board widget'''

--- a/src/Frames/reddit/threadFrame.py
+++ b/src/Frames/reddit/threadFrame.py
@@ -24,7 +24,6 @@ class RedditThreadFrame(AbstractFrame):
     def loader(self):
         self.comments = self.getJSONThread()
         self.contents = self.buildFrame()
-        urwid.WidgetWrap.__init__(self, self.contents)
 
     def getJSONThread(self):
         response = requests.get(self.url + '.json', headers=self.headers)


### PR DESCRIPTION
So, it looks like all frames have `self.contents`. We should be setting that in the loader, then, the `        urwid.WidgetWrap.__init__(self, self.contents)` can get called from the method implemented in the abstract class (`load`). 

