### PR TITLE
Fix: Added back line in systemcommands.py

### DIFF
--- a/src/Commands/SystemCommands.py
+++ b/src/Commands/SystemCommands.py
@@ -65,6 +65,7 @@ def systemCommands(cmd, uvm):
 
     elif cmd[0] in ('h', 'history'):
         if len(cmd) is 2:
+            h = uvm.history[int(cmd[1])]
             setattr(uvm.currFocusView, 'frame', h[1](h[2]))
         else:
             for h in uvm.history[1:]:


### PR DESCRIPTION
# Description

Must have accidentally removed a line from system commands while adding in new config setup. Sorry about that.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [x] My code is self documenting
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new major crashes/bugs