### PR TITLE
handleKey: ignore mouse tuples

### DIFF
--- a/commandChanVim.py
+++ b/commandChanVim.py
@@ -121,22 +121,23 @@ class urwidView():
                         pop_ups=True).run()
 
     def handleKey(self, key):
-        if key == ':':
-            self.mode = MODE.COMMAND
-            self.commandBar.set_caption(':')
-            self.body.focus_position = 'footer'
-            self.renderScreen()
+        if not isinstance(key, tuple): # avoid mouse click event tuples
+            if key == ':':
+                self.mode = MODE.COMMAND
+                self.commandBar.set_caption(':')
+                self.body.focus_position = 'footer'
+                self.renderScreen()
 
-        if self.mode is MODE.NORMAL:
-            rows, cols = urwid.raw_display.Screen().get_cols_rows()
-            DEBUG(key)
-            if key.isalpha():
-                key = key.lower()
-            
-            if key not in urwidView.KEYMAP.keys():
-                return
 
-            self.body.keypress((rows, cols), urwidView.KEYMAP[key])
+            if self.mode is MODE.NORMAL:
+                if key.isalpha():
+                    key = key.lower()
+
+                if key not in urwidView.KEYMAP.keys():
+                    return
+
+                rows, cols = urwid.raw_display.Screen().get_cols_rows()
+                self.body.keypress((rows, cols), urwidView.KEYMAP[key])
 
 ################################################################################
 


### PR DESCRIPTION
# Description

Mouse events are passed through uriwd as tuples. Ignore them in handleKey.

Fixes #57 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style of this project
- [X] I have performed a self-review of my own code
- [X] My code is self documenting
- [X] My changes generate no new major crashes/bugs
